### PR TITLE
chore(ci): Remove redundant sha check

### DIFF
--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -17,46 +17,27 @@ echo "Creating split-format Talos image for ${ARCH} (${VERSION})..."
 mkdir -p "${WORK_DIR}"
 cd "${WORK_DIR}"
 
-# Step 1: Download checksums
-echo "Step 1: Downloading checksums..."
-curl -L -f "${BASE_URL}/sha256sum.txt" -o "${WORK_DIR}/sha256sum.txt"
-
-# Step 2: Download image (if not already present)
-echo "Step 2: Downloading ${RAW_FILE}..."
+# Step 1: Download image (if not already present)
+echo "Step 1: Downloading ${RAW_FILE}..."
 if [ -f "${RAW_FILE}" ]; then
-  echo "  File already exists, skipping download"
+  echo "  File already exists (presumably verified via cosign), skipping download"
 else
   curl -L -f "${BASE_URL}/metal-${ARCH}.raw.zst" -o "${RAW_FILE}"
+  echo "  Note: Image should be verified via cosign before processing"
 fi
 
-# Step 3: Verify checksum
-echo "Step 3: Verifying checksum..."
-EXPECTED_HASH=$(grep "metal-${ARCH}.raw.zst" "${WORK_DIR}/sha256sum.txt" | awk '{print $1}')
-if [ -z "${EXPECTED_HASH}" ]; then
-  echo "Error: Could not find checksum for metal-${ARCH}.raw.zst in sha256sum.txt"
-  exit 1
-fi
-ACTUAL_HASH=$(sha256sum "${RAW_FILE}" | awk '{print $1}')
-if [ "${EXPECTED_HASH}" != "${ACTUAL_HASH}" ]; then
-  echo "Error: Checksum mismatch for metal-${ARCH}.raw.zst"
-  echo "  Expected: ${EXPECTED_HASH}"
-  echo "  Actual:   ${ACTUAL_HASH}"
-  exit 1
-fi
-echo "✓ Checksum verified: ${EXPECTED_HASH}"
-
-# Step 4: Decompress
+# Step 2: Decompress
 echo "Step 4: Decompressing..."
 RAW_DECOMPRESSED="${WORK_DIR}/metal-${ARCH}.raw"
 zstd -d "${RAW_FILE}" -o "${RAW_DECOMPRESSED}"
 
-# Step 5: Convert to qcow2
-echo "Step 5: Converting to qcow2..."
+# Step 3: Convert to qcow2
+echo "Step 3: Converting to qcow2..."
 QCOW2_FILE="${WORK_DIR}/talos-${ARCH}.qcow2"
 qemu-img convert -f raw -O qcow2 "${RAW_DECOMPRESSED}" "${QCOW2_FILE}"
 
-# Step 6: Create metadata.yaml
-echo "Step 6: Creating metadata.yaml..."
+# Step 4: Create metadata.yaml
+echo "Step 4: Creating metadata.yaml..."
 METADATA_YAML="${WORK_DIR}/metadata.yaml"
 cat > "${METADATA_YAML}" <<EOF
 architecture: "${ARCH}"
@@ -71,12 +52,12 @@ properties:
 templates: {}
 EOF
 
-# Step 7: Create metadata tarball
-echo "Step 7: Creating metadata tarball..."
+# Step 5: Create metadata tarball
+echo "Step 5: Creating metadata tarball..."
 tar -cJf "${ORIG_DIR}/${METADATA_TARBALL}" "metadata.yaml"
 
-# Step 8: Copy disk image
-echo "Step 8: Preparing disk image..."
+# Step 6: Copy disk image
+echo "Step 6: Preparing disk image..."
 cp "${QCOW2_FILE}" "${ORIG_DIR}/${DISK_FILE}"
 
 # Cleanup


### PR DESCRIPTION
Now that we verify images with cosign, this step is unnecessary.